### PR TITLE
Add option to set statusline highlight group to be used when showing a message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ let g:keepeye_message = 'SAVE YOUR EYES, TAKE A BREAK' " set the message to show
 let g:keepeye_system_bell = v:false                    " enable the bell sound (1)
 let g:keepeye_system_notification = v:false            " enable the system notification (2)
 let g:keepeye_timer = 1500                             " set the work time, 25min by default
+let g:keepeye_statusline_hl_group = 0                  " Use specific statusline hl group when message is shown
 ```
 1. [mpv](https://mpv.io/) is required for this feature
 2. only Linux systems are supported for this feature

--- a/autoload/keepeye.vim
+++ b/autoload/keepeye.vim
@@ -9,7 +9,7 @@ function! keepeye#Callback() abort
     AirlineToggle
   endif
 
-  let &statusline = s:message
+  let &statusline = s:getHighlightGroup().s:message
 
   if g:keepeye_system_bell
     call keepeye#system#Bell()
@@ -39,7 +39,7 @@ function! keepeye#Clear() abort
 endfunction
 
 function! keepeye#hasAirline() abort
-  return exists('g:loaded_airline') && g:loaded_airline 
+  return exists('g:loaded_airline') && g:loaded_airline
 endfunction
 
 function! keepeye#isAirlineVisible() abort
@@ -49,5 +49,13 @@ endfunction
 function! keepeye#Start() abort
   call keepeye#Clear()
   call timer_start(g:keepeye_timer*1000, 'keepeye#CallbackWrapper')
+endfunction
+
+function! s:getHighlightGroup() abort
+  if g:keepeye_statusline_hl_group == 0
+    return ''
+  endif
+
+  return '%'.g:keepeye_statusline_hl_group.'*'
 endfunction
 

--- a/doc/keepeye.txt
+++ b/doc/keepeye.txt
@@ -56,4 +56,12 @@ To change the timer (in seconds):
 >
   let g:keepeye_timer = 1500 " (25min, like the Pomodoro Technique)
 <
+To use specific statusline highlight group (`see :help hl-User1..9`) when
+showing a message, set this to the number of the higlight group you want to
+use. For example, to use red background with white text, add this to vimrc:
+>
+  hi User1 guifg=#FFFFFF guifb=#FF0000
+  let g:keepeye_statusline_hl_group = 1
+<
+
 vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/keepeye.vim
+++ b/plugin/keepeye.vim
@@ -5,6 +5,7 @@ let g:keepeye_system_bell = get(g:, 'keepeye_system_bell', v:false)
 let g:keepeye_system_notification = get(g:, 'keepeye_system_notification', v:false)
 let g:keepeye_timer = get(g:, 'keepeye_timer', 1500)
 let g:keepeye_bell_path = resolve(expand('<sfile>:h') . '/../media/bell.mp3')
+let g:keepeye_statusline_hl_group = get(g:, 'keepeye_statusline_hl_group', 0)
 
 command! -range KeepEye call keepeye#Start()
 command! -range KeepEyeClear call keepeye#Clear()


### PR DESCRIPTION
Since the default message is hardly visible to me, i wanted to make it more visible with the statusline highlight group. So i tried using this:
```vimL
hi User1 guifg=#FFFFFF guibg=#FF0000
let g:keepeye_message = '%1*SAVE YOUR EYES, TAKE A BREAK'
```
But that's not working as intended because the padding is added to make the message centered.
![screenshot](https://i.imgur.com/jqcFYSJ.png)

So i added an optional variable that can be set to any number from 1 to 9, and it will use `User1..9` respectively.

I'm just not sure how will this reflect airline users, since i'm not using airline.